### PR TITLE
Allow select and copy of Completion text

### DIFF
--- a/mlx-swift-chat/ContentView.swift
+++ b/mlx-swift-chat/ContentView.swift
@@ -144,5 +144,6 @@ struct PromptAndCompletionView: View {
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
     }
 }


### PR DESCRIPTION
This small change allows the user to select text on the Completion window. 

The text can then be copied, translated, even spoken by the text-to-speach service in macOS.

Fixes #10 